### PR TITLE
Fix bug in implicit lineto, bump version, add tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for perl module Image::SVG::Path
 
-0.21 2016-07-26
+0.23 2016-07-27
+
+* Bump version number, fix bug in implicit line-tos
+
+0.22 2016-07-26
 
 * Handle implicit line-to's in extended move-to syntax
 

--- a/lib/Image/SVG/Path.pm
+++ b/lib/Image/SVG/Path.pm
@@ -4,7 +4,7 @@ use strict;
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw/extract_path_info reverse_path create_path_string/;
-our $VERSION = '0.20';
+our $VERSION = '0.23';
 use Carp;
 
 # These are fields in the "arc" hash.
@@ -184,7 +184,7 @@ sub extract_path_info
 	    print "$me: dealing with extra stuff in ", join (', ', @coords),
 	    ".\n";
 	}
-	push @path_info, build_lineto($position, @coords);
+	push @path_info, build_lineto($position, splice @coords, 2);
     }
     # Deal with the rest of the path.
     my @curves;

--- a/t/Image-SVG-Path.t
+++ b/t/Image-SVG-Path.t
@@ -34,22 +34,28 @@ eval {
 };
 ok (! $@, "parse exponential");
 
-my $implicit = 'M 0,0 -1.733,-6.165';
+my $implicit = 'M 1,1 -2,-6';
 my @implicit_info;
 eval {
     @implicit_info = extract_path_info ($implicit);
 };
 ok (! $@, "parse implicit OK");
+my $implicit_info_keys = join '', map { $_->{svg_key} } @implicit_info;
+is ($implicit_info_keys, 'ML', '... only added one SVG element');
 is ($implicit_info[1]{type}, 'line-to', "Got lineto from implicit");
-is ($implicit_info[1]{position}, "absolute");
+is ($implicit_info[1]{position}, "absolute", '... position absolute');
+is_deeply ($implicit_info[1]{point}, [-2, -6], '... implicit lineto point');
 my $lc_implicit = lc $implicit;
 my @lc_implicit_info;
 eval {
     @lc_implicit_info = extract_path_info ($lc_implicit);
 };
 ok (! $@, "parse implicit OK");
+my $lc_implicit_info_keys = join '', map { $_->{svg_key} } @lc_implicit_info;
+is ($lc_implicit_info_keys, 'ml', '... only added one SVG element');
 is ($lc_implicit_info[1]{type}, 'line-to', "Got lineto from implicit");
-is ($lc_implicit_info[1]{position}, "relative");
+is ($lc_implicit_info[1]{position}, "relative", "... position relative");
+is_deeply ($implicit_info[1]{point}, [-2, -6], 'implicit lineto point');
 
 my $arc = <<EOF;
 M600,350 l 50,-25 
@@ -99,8 +105,9 @@ is_deeply ($dblm_info[3]{end}, [200,130]);
 
 my $dblm2 = 'M 50 10 Q 0 70 50 130 M 200 10 200 20';
 @dblm_info = extract_path_info ($dblm2);
-diag explain @dblm_info;
 is ($dblm_info[2]{svg_key}, 'M', "Got second M in path");
+my $dblm_info_keys = join '', map { $_->{svg_key} } @dblm_info;
+is        ($dblm_info_keys, 'MQML', 'Checking inserted implict lineto sequence');
 is_deeply ($dblm_info[2]{point}, [200,10], "Got correct point value");
 is        ($dblm_info[3]{name},  'lineto', "Inserted implicit moveto");
 is_deeply ($dblm_info[3]{point}, [200,20], "... Got correct point value");


### PR DESCRIPTION
I fixed the bug that I created in the initial moveto handling of implicit lineto's.  The second thing that you mentioned though isn't happening, because the splice on the lines above actually prunes out all the other coordinates.  I added some tests to verify that.

Thank you for accepting these patches (even with bugs!) and doing releases so quickly.