### PR TITLE
Handle mulitple Arc commands

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl module Image::SVG::Path
 
+0.24 2016-08-09
+
+* Handle multiple Arc commands in sequence
+
 0.23 2016-07-27
 
 * Bump version number, fix bug in implicit line-tos

--- a/lib/Image/SVG/Path.pm
+++ b/lib/Image/SVG/Path.pm
@@ -4,7 +4,7 @@ use strict;
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw/extract_path_info reverse_path create_path_string/;
-our $VERSION = '0.23';
+our $VERSION = '0.24';
 use Carp;
 
 # These are fields in the "arc" hash.
@@ -330,16 +330,20 @@ sub extract_path_info
         }
         elsif (uc $curve_type eq 'A') {
             my $position = position_type ($curve_type);
-	    if (@numbers != 7) {
+            my $expect_numbers = 7;
+	    if (@numbers % $expect_numbers != 0) {
 		croak "Need 7 parameters for arc";
 	    }
-	    my %arc;
-	    $arc{svg_key} = $curve_type;
-	    $arc{type} = 'arc';
-	    $arc{name} = 'elliptical arc';
-	    $arc{position} = $position;
-	    @arc{@arc_fields} = @numbers;
-	    push @path_info, \%arc;
+            for (my $i = 0; $i < @numbers / $expect_numbers; $i++) {
+                my $o = $expect_numbers * $i;
+                my %arc;
+                $arc{svg_key} = $curve_type;
+                $arc{type} = 'arc';
+                $arc{name} = 'elliptical arc';
+                $arc{position} = $position;
+                @arc{@arc_fields} = @numbers[$o .. $o + 6];
+                push @path_info, \%arc;
+            }
         }
 	elsif (uc $curve_type eq 'M') {
 	    my $position = position_type ($curve_type);

--- a/t/doubled_path_commands.t
+++ b/t/doubled_path_commands.t
@@ -1,0 +1,35 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Exception;
+use Image::SVG::Path qw/extract_path_info/;
+
+##Check to see that doubled, implicit commands work for all types
+
+my @sets = (
+    'L', 2, 'Double line-to L',
+    'H', 1, 'Double Horizontal line H',
+    'V', 1, 'Double Vertical line V',
+    'M', 2, 'Double move-to M', ##Note, have to use 2 M commands, since extra coordinates in initial M are converted to move-to's!
+    'C', 6, 'Double Cubic C',
+    'S', 4, 'Double Shorthand cubic S',
+    'Q', 4, 'Double Bezier Q',
+    'T', 2, 'Double Shorthand bezier T',
+    'A', 7, 'Double Arc A',
+);
+
+my @foo;
+while(my ($element, $arg_count, $comment) = splice @sets, 0, 3) {
+    ##Dynamically build a path string to parse, we don't care about the formatting so much as the contents
+    my $command = 'M 1 2 ';
+    $command .= join ' ', $element, (1..2*$arg_count);
+    $command .= ' Z';
+    diag $command;
+    my $lived = lives_ok { @foo = extract_path_info($command); } $comment;
+    SKIP: {
+        skip "$comment failed anyway", 1 unless $lived;
+        is @foo, 4, "Received 4 path elements for $comment";
+    }
+}
+
+done_testing();


### PR DESCRIPTION
We found out Image::SVG::Path doesn't handle multiple Arc commands, where you'd skip putting in the A between adjacent arcs.

This patch bumps the version number to 0.24, adds a patch for handling multiple arc commands (arguments in sets of 7) and adds a test for testing all the commands with multiple implicit sets.