### PR TITLE
Handle plus signs in numbers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl module Image::SVG::Path
 
+0.26 2016-10-10
+
+* Handle + signs in exponentials, and as a number separator
+
 0.25 2016-09-08
 
 * Handle multiple closepath (z) commands in sequence

--- a/lib/Image/SVG/Path.pm
+++ b/lib/Image/SVG/Path.pm
@@ -4,7 +4,7 @@ use strict;
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw/extract_path_info reverse_path create_path_string/;
-our $VERSION = '0.25';
+our $VERSION = '0.26';
 use Carp;
 
 # These are fields in the "arc" hash.
@@ -116,7 +116,7 @@ sub create_path_string
 }
 
 # The following regular expression splits the path into pieces
-# Note we only split on '-' when it's not preceeded by 'e'
+# Note we only split on '-' or '+' when not preceeded by 'e'
 
 my $split_re = qr/
 		     (?:
@@ -124,13 +124,16 @@ my $split_re = qr/
 		     |
 			 (?<!e)(?=-)
 		     |
+			 (?<!e)(?:\+)
+		     |
 			 \s+
 		     )
 		 /x;
 
 # Match a number
 
-my $number_re = qr/[-0-9.e]+/i;
+my $number_re = qr/[\+\-0-9.e]+/i;
+
 
 my $numbers_re = qr/(?:$number_re|(?:\s|,)+)*/;
 

--- a/lib/Image/SVG/Path.pod.tmpl
+++ b/lib/Image/SVG/Path.pod.tmpl
@@ -429,8 +429,9 @@ either this or SVG Tiny are in use.
 
 =head1 ACKNOWLEDGEMENTS
 
-Colin Kuskie (L<http://www.perldreamer.com/>) fixed error messages for
+Colin Kuskie (L<http://www.thegamecrafter.com/>) fixed error messages for
 version 0.20, number paths for version 0.21, and implicit line-tos for
-version 0.22.
+version 0.22, multiple Arc commands in 0.24, multiple closepath commands in 0.25 and
+handling plus signs in numbers in 0.26.
 
 [% INCLUDE "author" %]

--- a/t/Image-SVG-Path.t
+++ b/t/Image-SVG-Path.t
@@ -1,5 +1,6 @@
 use warnings;
 use strict;
+use blib;
 use Test::More;
 use Image::SVG::Path qw/extract_path_info create_path_string/;
 

--- a/t/svg_signs.t
+++ b/t/svg_signs.t
@@ -1,0 +1,52 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Exception;
+use blib;
+use Image::SVG::Path qw/extract_path_info/;
+
+##Test these different syntaxes to check for path parsing
+
+my @strings = (
+    'M2 3',   [2, 3],   'Integer, space separator',
+    'M2,3',   [2, 3],   'Integer, comma separator',
+    'M2-3',   [2, -3],  'Integer, - separator',
+    'M-2-3', [-2, -3], 'Negative integers, - separator',
+
+    'M2+3', [2, 3],    'Integer, + separator',
+
+    'M2.1 3.1', [2.1, 3.1],    'Floats, space separator',
+    'M2.1+3.1', [2.1, 3.1],    'Floats, + separators',
+    'M2.1-3.1', [2.1, -3.1],    'Floats, - separators',
+    'M2.1 -3.1', [2.1, -3.1],    'Floats, - and space separators',
+    'M-2.1-3.1', [-2.1, -3.1],    'Floats, - separators',
+    'M-2.1+3.1', [-2.1, 3.1],    'Floats, -,+ separators',
+
+    ##Have to compare these as strings, or perl helpfully upgrades the numbers
+    'M2e1 3e1', ['2e1', '3e1'],    'Exponentials, space separator',
+    'M2e1-3e1', ['2e1', '-3e1'],    'Exponentials, - separator',
+    'M2e1+3e1', ['2e1', '3e1'],    'Exponentials, + separator',
+    'M-2e1-3e1', ['-2e1', '-3e1'],    'Exponentials, - separators',
+
+    'M2e-1 3e-1', ['2e-1', '3e-1'],    'Small Exponentials, space separator',
+    'M2e-1-3e-1', ['2e-1', '-3e-1'],    'Small Exponentials, - separator',
+    'M2e-1+3e-1', ['2e-1', '3e-1'],    'Small Exponentials, + separator',
+    'M-2e-1-3e-1', ['-2e-1', '-3e-1'],    'Small Exponentials, - separators',
+
+    'M2e+1 3e+1', ['2e+1', '3e+1'],    'Large Exponentials, space separator',
+    'M2e+1-3e+1', ['2e+1', '-3e+1'],    'Large Exponentials, - separator',
+    'M2e+1+3e+1', ['2e+1', '3e+1'],    'Large Exponentials, + separator',
+    'M-2e+1-3e+1', ['-2e+1', '-3e+1'],    'Large Exponentials, - separators',
+
+);
+
+while(my ($string,$numbers,$comment) = splice @strings, 0, 3) {
+    my @foo;
+    my $passed = lives_ok { @foo = extract_path_info($string, { verbose => 0, }); } $comment;
+    SKIP: {
+        skip 'Parsing failed', 1 unless $passed;
+        is_deeply $foo[0]->{point}, $numbers, '... numbers';
+    }
+}
+
+done_testing();


### PR DESCRIPTION
This patch, and the new test file, check that Image::SVG::Path can handle + signs in exponentials, and as a separator between numbers.

I also added 'use blib' to the tests, so that I didn't have to install the module locally to test it.